### PR TITLE
Add Node version file and update setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ is built with React and Vite and lives under the [`frontend-app/`](frontend-app/
 - **Node.js** >= 18 (see `.nvmrc`)
 - **npm** (comes with Node.js)
 
-## Getting started
+## Setup
 
 Ensure you are using Node.js 18. If you have `nvm` installed you can simply
 run `nvm use` in the project root to activate the version specified in


### PR DESCRIPTION
## Summary
- switch `Getting started` header to `Setup`
- remind developers to use Node v18 via `nvm`

## Testing
- `npm run lint` *(fails: ESLint config not found)*
- `npm run stylelint` *(fails: stylelint not found)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68488bf6c31c833299f2319960ccb15e