### PR TITLE
Implement quick lead generation wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,17 @@ npm run build   # compile for production
 
 The build output is placed in `frontend-app/dist/`.
 
+## Lead Generation Wizard
+
+The home page includes a quick wizard that collects a trade category, postcode,
+desired start date, and contact info. After the final step it calls the API at
+`/api/lead-gen/jobs/draft` using the base URL defined in `VITE_API_BASE_URL` and
+navigates to `/job/new`.
+
+To run the frontend against a different API backend set the environment variable
+before starting Vite:
+
+```bash
+VITE_API_BASE_URL=https://api.example.com npm run dev
+```
+

--- a/frontend-app/src/features/leadgen/QuickWizard.tsx
+++ b/frontend-app/src/features/leadgen/QuickWizard.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { LeadGenService } from '../../services/leadGenService';
+import { logEvent } from '../../utils/analytics';
+import { Button } from '../../components/Button';
+
+interface Props {
+  onStart?: () => void;
+  onComplete?: (token: string) => void;
+}
+
+const categories = ['Plumbing', 'Electrical', 'HVAC', 'Renovation', 'Solar'];
+
+export const QuickWizard = ({ onStart, onComplete }: Props) => {
+  const [step, setStep] = useState(0);
+  const [category, setCategory] = useState('');
+  const [postcode, setPostcode] = useState('');
+  const [date, setDate] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (step === 0) onStart?.();
+  }, [step, onStart]);
+
+  const next = () => {
+    setStep((s) => {
+      const nextStep = s + 1;
+      logEvent('wizard_step', { step: nextStep });
+      return nextStep;
+    });
+  };
+
+  const handleSubmit = async () => {
+    setStep(4);
+    logEvent('wizard_complete');
+    try {
+      const { data } = await LeadGenService.createJobDraft({
+        category,
+        postcode,
+        date,
+        email,
+        phone,
+      });
+      onComplete?.(data.token);
+    } finally {
+      navigate('/job/new');
+    }
+  };
+
+  return (
+    <div className="bg-white p-4 rounded shadow-md text-left">
+      {step === 0 && (
+        <div>
+          <h3 className="font-semibold mb-4">What do you need help with?</h3>
+          <div className="grid grid-cols-2 gap-2">
+            {categories.map((c) => (
+              <button
+                key={c}
+                onClick={() => {
+                  setCategory(c);
+                  next();
+                }}
+                className="border border-primary rounded p-2 text-sm hover:bg-primary hover:text-white"
+              >
+                {c}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {step === 1 && (
+        <div className="space-y-4">
+          <label className="block text-sm font-medium">Postcode</label>
+          <input
+            type="text"
+            value={postcode}
+            onChange={(e) => setPostcode(e.target.value)}
+            placeholder="B3J 2K9"
+            pattern="[A-Za-z]\d[A-Za-z][ -]?\d[A-Za-z]\d"
+            className="w-full border p-2 rounded"
+          />
+          <Button onClick={next} disabled={!postcode.match(/^[A-Za-z]\d[A-Za-z][ -]?\d[A-Za-z]\d$/)}>
+            Next
+          </Button>
+        </div>
+      )}
+
+      {step === 2 && (
+        <div className="space-y-4">
+          <label className="block text-sm font-medium">When do you need it?</label>
+          <input
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            className="w-full border p-2 rounded"
+          />
+          <div>
+            <button
+              onClick={() => {
+                setDate('ASAP');
+                next();
+              }}
+              className="underline text-sm text-primary"
+            >
+              ASAP
+            </button>
+          </div>
+          {date && <Button onClick={next}>Next</Button>}
+        </div>
+      )}
+
+      {step === 3 && (
+        <div className="space-y-4">
+          <label className="block text-sm font-medium">Email</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full border p-2 rounded"
+          />
+          <label className="block text-sm font-medium">Phone</label>
+          <input
+            type="tel"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            className="w-full border p-2 rounded"
+          />
+          <Button onClick={handleSubmit} disabled={!email && !phone}>
+            Get My Quotes
+          </Button>
+        </div>
+      )}
+
+      {step === 4 && (
+        <div className="flex items-center gap-2">
+          <svg className="animate-spin h-5 w-5 text-primary" viewBox="0 0 24 24">
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+              fill="none"
+            />
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+            />
+          </svg>
+          <span>Finding local matches…</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default QuickWizard;

--- a/frontend-app/src/main.tsx
+++ b/frontend-app/src/main.tsx
@@ -7,6 +7,7 @@ import Dashboard from './features/dashboard/Dashboard';
 import './index.css';
 import HomePage from './pages/Home/HomePage';
 import Layout from './pages/Layout/Layout';
+import NewJobPage from './pages/Job/NewJobPage';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
@@ -18,6 +19,7 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <Route path="/login" element={<LoginPage />} />
     <Route path="/signup" element={<SignupPage />} />
     <Route path="/dashboard" element={<Dashboard />} />
+    <Route path="/job/new" element={<NewJobPage />} />
     </Route>
   </Routes>
 </BrowserRouter>

--- a/frontend-app/src/pages/Home/HeroSection.tsx
+++ b/frontend-app/src/pages/Home/HeroSection.tsx
@@ -1,20 +1,49 @@
-import React from 'react';
+import { useState } from 'react';
 import { Button } from '../../components/Button';
+import QuickWizard from '../../features/leadgen/QuickWizard';
+import { logEvent } from '../../utils/analytics';
 
 
-const HeroSection = () => (
-  <section className="bg-base text-center py-16 px-4">
-    <h1 className="text-4xl font-bold text-gray-900 max-w-2xl mx-auto">
-      Find Trusted Contractors in Nova Scotia
-    </h1>
-    <p className="mt-4 text-lg text-gray-600 max-w-xl mx-auto">
-      Licensed. Verified. Local. Get quotes, not headaches.
-    </p>
-    <div className="mt-6 flex flex-col sm:flex-row justify-center gap-4">
-      <Button variant="primary">Post a Job</Button>
-      <Button variant="outline">Browse Contractors</Button>
-      <Button variant="ghost">Join as Pro</Button>
-    </div>
-  </section>
-);
+const HeroSection = () => {
+  const [showWizard, setShowWizard] = useState(false);
+
+  const handleClick = () => {
+    logEvent('cta_click', { source: 'hero' });
+    setShowWizard((s) => !s);
+  };
+
+  return (
+    <section className="bg-base py-16 px-4">
+      <div className="max-w-6xl mx-auto grid md:grid-cols-2 items-center gap-10">
+        <div className="text-center md:text-left">
+          <h1 className="text-4xl font-bold text-gray-900 max-w-2xl">
+            Find Trusted Contractors in Nova Scotia
+          </h1>
+          <p className="mt-4 text-lg text-gray-600 max-w-xl">
+            Licensed. Verified. Local. Get quotes, not headaches.
+          </p>
+          <div className="mt-6">
+            <Button
+              variant="primary"
+              onClick={handleClick}
+              className="bg-primary hover:bg-primary-hover"
+            >
+              Get Free Quotes
+            </Button>
+          </div>
+        </div>
+        <img
+          src="/hero.jpg"
+          alt="Renovation"
+          className="hidden md:block rounded-lg w-full"
+        />
+      </div>
+      {showWizard && (
+        <div className="mt-8 max-w-md mx-auto">
+          <QuickWizard onStart={() => logEvent('wizard_start')} onComplete={() => logEvent('wizard_complete')} />
+        </div>
+      )}
+    </section>
+  );
+};
 export default HeroSection;

--- a/frontend-app/src/pages/Home/HomePage.tsx
+++ b/frontend-app/src/pages/Home/HomePage.tsx
@@ -5,6 +5,7 @@ import CategoriesSection from './CategoriesSection';
 import TestimonialsSection from './TestimonialsSection';
 import ContractorHighlights from './ContractorHighlights';
 import WhyCheckTradeSection from './WhyCheckTradeSection';
+import LocationsGrid from './LocationsGrid';
 import NewsletterSection from './NewsletterSection';
 import { RegisterModal } from '../../components/auth/RegisterModal';
 import StickyFooterCTA from './StickyFooterCTA';
@@ -20,6 +21,7 @@ const HomePage: React.FC = () => {
       <HeroSection  />
       <HowItWorksSection onGetStartedClick={handleOpenRegister} />
       <CategoriesSection />
+      <LocationsGrid />
       <TestimonialsSection />
       <ContractorHighlights />
       <WhyCheckTradeSection />

--- a/frontend-app/src/pages/Home/LocationsGrid.tsx
+++ b/frontend-app/src/pages/Home/LocationsGrid.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import { SectionWrapper } from '../../components/SectionWrapper';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+
+const locations = [
+  'Halifax',
+  'Dartmouth',
+  'Sydney',
+  'Truro',
+  'New Glasgow',
+  'Bridgewater',
+  'Kentville',
+  'Yarmouth',
+];
+
+const LocationsGrid = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <SectionWrapper title="Find plumbers in…" className="bg-white">
+      <button
+        onClick={() => setOpen(!open)}
+        className="mb-4 flex items-center text-primary font-semibold"
+      >
+        {open ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+        <span className="ml-2">{open ? 'Hide locations' : 'Show locations'}</span>
+      </button>
+      {open && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 text-sm">
+          {locations.map((loc) => (
+            <div key={loc} className="bg-base p-2 rounded">
+              {loc}
+            </div>
+          ))}
+        </div>
+      )}
+    </SectionWrapper>
+  );
+};
+
+export default LocationsGrid;

--- a/frontend-app/src/pages/Home/StickyFooterCTA.tsx
+++ b/frontend-app/src/pages/Home/StickyFooterCTA.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { logEvent } from '../../utils/analytics';
 
 interface Props {
   onClick: () => void;
@@ -8,9 +8,12 @@ const StickyFooterCTA: React.FC<Props> = ({ onClick }) => {
   return (
     <div className="fixed bottom-0 left-0 w-full bg-white border-t border-gray-200 shadow-md sm:hidden z-50">
       <div className="max-w-2xl mx-auto px-4 py-3 flex justify-between items-center">
-        <div className="text-sm font-medium text-gray-800">Ready to hire a trusted pro?</div>
+        <div className="text-sm font-medium text-gray-800">Get free quotes in 30 seconds</div>
         <button
-          onClick={onClick}
+          onClick={() => {
+            logEvent('cta_click', { source: 'mobile_sticky' });
+            onClick();
+          }}
           className="bg-primary text-white font-semibold py-2 px-4 rounded-full text-sm"
         >
           Get Started

--- a/frontend-app/src/pages/Home/TestimonialsSection.tsx
+++ b/frontend-app/src/pages/Home/TestimonialsSection.tsx
@@ -1,17 +1,38 @@
-import { SectionWrapper } from "../../components/SectionWrapper";
+import { SectionWrapper } from '../../components/SectionWrapper';
+import { Star } from 'lucide-react';
 
 const testimonials = [
-  { name: 'James — Halifax', quote: '“Saved me hours. The quote I got was fair and quick.”' },
-  { name: 'Sara — Sydney', quote: '“I loved how local and personal everything felt.”' },
+  {
+    name: 'James',
+    location: 'Halifax',
+    quote: '“Saved me hours. The quote I got was fair and quick.”',
+    avatar: '/avatars/james.jpg',
+  },
+  {
+    name: 'Sara',
+    location: 'Sydney',
+    quote: '“I loved how local and personal everything felt.”',
+    avatar: '/avatars/sara.jpg',
+  },
 ];
 
 const TestimonialsSection = () => (
   <SectionWrapper id="testimonials" title="What Homeowners Say" className="bg-white">
     <div className="grid gap-6 sm:grid-cols-2">
       {testimonials.map((t, i) => (
-        <div key={i} className="bg-base border-l-4 border-primary p-6 rounded shadow-sm">
-          <p className="italic text-gray-700">{t.quote}</p>
-          <p className="mt-4 font-semibold text-right text-gray-800">{t.name}</p>
+        <div key={i} className="bg-base p-6 rounded shadow-sm flex gap-4 items-start">
+          <img src={t.avatar} alt={t.name} className="w-12 h-12 rounded-full object-cover" />
+          <div>
+            <p className="italic text-gray-700">{t.quote}</p>
+            <div className="flex items-center text-yellow-500 my-2">
+              {Array.from({ length: 5 }).map((_, idx) => (
+                <Star key={idx} className="w-4 h-4 fill-current" />
+              ))}
+            </div>
+            <p className="font-semibold text-gray-800">
+              {t.name} — {t.location}
+            </p>
+          </div>
         </div>
       ))}
     </div>

--- a/frontend-app/src/pages/Job/NewJobPage.tsx
+++ b/frontend-app/src/pages/Job/NewJobPage.tsx
@@ -1,0 +1,5 @@
+const NewJobPage = () => (
+  <div className="p-4">Job draft created. Coming soon.</div>
+);
+
+export default NewJobPage;

--- a/frontend-app/src/services/leadGenService.ts
+++ b/frontend-app/src/services/leadGenService.ts
@@ -1,0 +1,16 @@
+import http from '../api/httpClient';
+
+export interface DraftJobRequest {
+  category: string;
+  postcode: string;
+  date: string;
+  email: string;
+  phone: string;
+}
+
+const createJobDraft = (data: DraftJobRequest) =>
+  http.post<{ token: string }>('/api/lead-gen/jobs/draft', data);
+
+export const LeadGenService = {
+  createJobDraft,
+};

--- a/frontend-app/src/utils/analytics.ts
+++ b/frontend-app/src/utils/analytics.ts
@@ -1,0 +1,5 @@
+export const logEvent = (name: string, data?: unknown) => {
+  // Simple console logger - replace with real analytics
+  // eslint-disable-next-line no-console
+  console.log('[analytics]', name, data);
+};


### PR DESCRIPTION
## Summary
- integrate lead gen wizard into hero section
- add sticky footer CTA and locations grid
- create QuickWizard component and lead generation service
- enhance testimonials with avatars and ratings
- add basic analytics logging
- document wizard flow and API base URL

## Testing
- `npm run lint` *(fails: many prettier errors)*
- `npm run stylelint`


------
https://chatgpt.com/codex/tasks/task_e_6849824e5a28833283b24e6ba8d963f6