### PR TITLE
Update home wizard toggling

### DIFF
--- a/frontend-app/src/pages/Home/HeroSection.tsx
+++ b/frontend-app/src/pages/Home/HeroSection.tsx
@@ -1,15 +1,17 @@
-import { useState } from 'react';
 import { Button } from '../../components/Button';
 import QuickWizard from '../../features/leadgen/QuickWizard';
 import { logEvent } from '../../utils/analytics';
 
+interface Props {
+  showWizard: boolean;
+  onToggleWizard: () => void;
+}
 
-const HeroSection = () => {
-  const [showWizard, setShowWizard] = useState(false);
 
+const HeroSection = ({ showWizard, onToggleWizard }: Props) => {
   const handleClick = () => {
     logEvent('cta_click', { source: 'hero' });
-    setShowWizard((s) => !s);
+    onToggleWizard();
   };
 
   return (

--- a/frontend-app/src/pages/Home/HomePage.tsx
+++ b/frontend-app/src/pages/Home/HomePage.tsx
@@ -7,27 +7,24 @@ import ContractorHighlights from './ContractorHighlights';
 import WhyCheckTradeSection from './WhyCheckTradeSection';
 import LocationsGrid from './LocationsGrid';
 import NewsletterSection from './NewsletterSection';
-import { RegisterModal } from '../../components/auth/RegisterModal';
 import StickyFooterCTA from './StickyFooterCTA';
 
 const HomePage: React.FC = () => {
-  const [showRegister, setShowRegister] = useState(false);
+  const [showWizard, setShowWizard] = useState(false);
 
-  const handleOpenRegister = () => setShowRegister(true);
-  const handleCloseRegister = () => setShowRegister(false);
+  const toggleWizard = () => setShowWizard((s) => !s);
 
   return (
     <main>
-      <HeroSection  />
-      <HowItWorksSection onGetStartedClick={handleOpenRegister} />
+      <HeroSection showWizard={showWizard} onToggleWizard={toggleWizard} />
+      <HowItWorksSection onGetStartedClick={toggleWizard} />
       <CategoriesSection />
       <LocationsGrid />
       <TestimonialsSection />
       <ContractorHighlights />
       <WhyCheckTradeSection />
-      <NewsletterSection onGetStartedClick={handleOpenRegister} />
-      <RegisterModal open={showRegister} onClose={handleCloseRegister} />
-      <StickyFooterCTA onClick={handleOpenRegister} />
+      <NewsletterSection onGetStartedClick={toggleWizard} />
+      <StickyFooterCTA onClick={toggleWizard} />
     </main>
   );
 };


### PR DESCRIPTION
## Summary
- toggle lead gen wizard via HomePage
- pass the toggle down to HeroSection and other CTAs

## Testing
- `npm run lint` *(fails: 2309 problems)*
- `npm run stylelint`
- `npm test --if-present`

------
https://chatgpt.com/codex/tasks/task_e_68498d81155883329f09d0d9be2c8ff5