### PR TITLE
Add ignore files for lint and prettier

### DIFF
--- a/frontend-app/.eslintignore
+++ b/frontend-app/.eslintignore
@@ -1,0 +1,2 @@
+src/types/openapi.d.ts
+dist/

--- a/frontend-app/.prettierignore
+++ b/frontend-app/.prettierignore
@@ -1,0 +1,2 @@
+src/types/openapi.d.ts
+dist/


### PR DESCRIPTION
## Summary
- add `.eslintignore` and `.prettierignore`
- ignore generated OpenAPI types and `dist` directory

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684991c352f883328b26d28f33452e5c