### PR TITLE
fix: ensure profile type import

### DIFF
--- a/frontend-app/src/store/useAuthStore.ts
+++ b/frontend-app/src/store/useAuthStore.ts
@@ -1,6 +1,14 @@
-import { create } from 'zustand';
-import { RegisterRequest, VerifyOtpRequest, ResendOtpRequest, registerUser, verifyOtp, resendOtp, getMyProfile } from '../api/identityApi';
 import { MyProfileDto } from '../types/common';
+import { create } from 'zustand';
+import {
+  RegisterRequest,
+  VerifyOtpRequest,
+  ResendOtpRequest,
+  registerUser,
+  verifyOtp,
+  resendOtp,
+  getMyProfile,
+} from '../api/identityApi';
 
 type AuthState = {
   profile: MyProfileDto | null;


### PR DESCRIPTION
## Summary
- adjust `useAuthStore` imports
- keep profile typed as `MyProfileDto | null`

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68499591bea4833295b42dc7d3fdae23