### PR TITLE
Implement property dashboard with job management

### DIFF
--- a/frontend-app/src/features/dashboard/Dashboard.tsx
+++ b/frontend-app/src/features/dashboard/Dashboard.tsx
@@ -1,7 +1,33 @@
-import React from 'react';
+import { useEffect, useState } from 'react';
+import propertyService, { Property } from '../../services/propertyService';
+import PropertyCard from './components/PropertyCard';
+import AddJobModal from './components/AddJobModal';
 
 function Dashboard() {
-  return <div className="p-4">Dashboard</div>;
+  const [properties, setProperties] = useState<Property[]>([]);
+  const [selected, setSelected] = useState<Property | null>(null);
+
+  useEffect(() => {
+    propertyService
+      .getProperties()
+      .then((res) => setProperties(res.data))
+      .catch(() => setProperties([]));
+  }, []);
+
+  return (
+    <div className="p-4 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">My Properties</h1>
+      {properties.map((p) => (
+        <PropertyCard key={p.id} property={p} onAddJob={setSelected} />
+      ))}
+      {properties.length === 0 && (
+        <p className="text-gray-500 text-sm">No properties found.</p>
+      )}
+      {selected && (
+        <AddJobModal property={selected} onClose={() => setSelected(null)} />
+      )}
+    </div>
+  );
 }
 
 export default Dashboard;

--- a/frontend-app/src/features/dashboard/components/AddJobForm.tsx
+++ b/frontend-app/src/features/dashboard/components/AddJobForm.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { Button } from '../../../components/Button';
+import jobService, { CreateJobRequest } from '../../../services/jobService';
+import { Property } from '../../../services/propertyService';
+
+interface Props {
+  property: Property;
+  onCreated?: () => void;
+}
+
+export const AddJobForm = ({ property, onCreated }: Props) => {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      const req: Partial<CreateJobRequest> = {
+        customerProfileId: '',
+        propertyId: property.id,
+        categoryId: '',
+        subcategoryId: '',
+        title,
+        description,
+      };
+      await jobService.createJob(req as CreateJobRequest);
+      onCreated?.();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 p-4">
+      <div className="text-sm text-gray-700">
+        Creating job for{' '}
+        <strong>{property.nickname || property.address?.line1}</strong>
+      </div>
+      <input
+        type="text"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="Job title"
+        className="w-full border p-2 rounded"
+      />
+      <textarea
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        placeholder="Job description"
+        className="w-full border p-2 rounded"
+      />
+      <Button type="submit" disabled={submitting || !title}>
+        Create Job
+      </Button>
+    </form>
+  );
+};
+
+export default AddJobForm;

--- a/frontend-app/src/features/dashboard/components/AddJobModal.tsx
+++ b/frontend-app/src/features/dashboard/components/AddJobModal.tsx
@@ -1,0 +1,16 @@
+import Modal from '../../../components/Modal';
+import { Property } from '../../../services/propertyService';
+import AddJobForm from './AddJobForm';
+
+interface Props {
+  property: Property;
+  onClose: () => void;
+}
+
+const AddJobModal = ({ property, onClose }: Props) => (
+  <Modal onClose={onClose}>
+    <AddJobForm property={property} onCreated={onClose} />
+  </Modal>
+);
+
+export default AddJobModal;

--- a/frontend-app/src/features/dashboard/components/PropertyCard.tsx
+++ b/frontend-app/src/features/dashboard/components/PropertyCard.tsx
@@ -1,0 +1,76 @@
+import { useState, useEffect } from 'react';
+import { Button } from '../../../components/Button';
+import propertyService, {
+  Property,
+  Job,
+} from '../../../services/propertyService';
+
+interface Props {
+  property: Property;
+  onAddJob: (property: Property) => void;
+}
+
+export const PropertyCard = ({ property, onAddJob }: Props) => {
+  const [jobs, setJobs] = useState<Job[]>([]);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    propertyService
+      .getPropertyJobs(property.id)
+      .then((res) => setJobs(res.data))
+      .catch(() => setJobs([]));
+  }, [open, property.id]);
+
+  const completed = jobs.filter((j) => j.status === 'Completed').length;
+  const pending = jobs.filter((j) => j.status !== 'Completed').length;
+  const quotesReceived = jobs.filter(
+    (j) => j.quoteStatus === 'Received',
+  ).length;
+  const quotesPending = jobs.filter((j) => j.quoteStatus !== 'Received').length;
+
+  return (
+    <div className="border rounded-lg p-4 bg-white shadow-sm mb-4">
+      <div className="flex justify-between items-center">
+        <div>
+          <h3 className="font-semibold text-lg">
+            {property.nickname || property.address?.line1}
+          </h3>
+          <p className="text-sm text-gray-600">
+            {property.address?.line1} {property.address?.city}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={() => onAddJob(property)}>
+            Add Job
+          </Button>
+          <Button variant="ghost" onClick={() => setOpen(!open)}>
+            {open ? 'Hide Jobs' : 'View Jobs'}
+          </Button>
+        </div>
+      </div>
+      {open && (
+        <div className="mt-4 space-y-2">
+          <div className="text-sm text-gray-700">
+            Jobs Completed: {completed} | Pending: {pending}
+          </div>
+          <div className="text-sm text-gray-700">
+            Quotes Received: {quotesReceived} | Pending: {quotesPending}
+          </div>
+          <ul className="mt-2 border-t pt-2 space-y-1">
+            {jobs.map((job) => (
+              <li key={job.id} className="text-sm">
+                {job.title} - {job.status}
+              </li>
+            ))}
+            {jobs.length === 0 && (
+              <li className="text-sm text-gray-500">No jobs found.</li>
+            )}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PropertyCard;

--- a/frontend-app/src/services/jobService.ts
+++ b/frontend-app/src/services/jobService.ts
@@ -26,10 +26,7 @@ export interface CreateJobRequest {
 export const createJob = (data: CreateJobRequest) =>
   http.post('/api/lead-gen/jobs', data);
 
-export const createJobDraft = (
-  data: unknown,
-  token?: string,
-) =>
+export const createJobDraft = (data: unknown, token?: string) =>
   http.post<{ token: string }>('/api/lead-gen/jobs/draft', data, {
     headers: token ? { 'Auto-Save-Token': token } : undefined,
   });
@@ -59,6 +56,9 @@ export const getJobSubcategories = (categoryId: string) =>
 export const getJobSubcategoryForm = (id: string) =>
   http.get(`/api/job-subcategories/${id}/form`);
 
+export const getJobsForProperty = (propertyId: string) =>
+  http.get(`/api/identity/properties/${propertyId}/jobs`);
+
 export default {
   createJob,
   createJobDraft,
@@ -66,4 +66,5 @@ export default {
   getJobCategories,
   getJobSubcategories,
   getJobSubcategoryForm,
+  getJobsForProperty,
 };

--- a/frontend-app/src/services/propertyService.ts
+++ b/frontend-app/src/services/propertyService.ts
@@ -1,0 +1,15 @@
+import http from '../api/httpClient';
+import { PropertyDto, JobDto } from '../types/common';
+
+export type Property = PropertyDto;
+export type Job = JobDto;
+
+const getProperties = () => http.get<Property[]>('/api/identity/properties');
+
+const getPropertyJobs = (propertyId: string) =>
+  http.get<Job[]>(`/api/identity/properties/${propertyId}/jobs`);
+
+export default {
+  getProperties,
+  getPropertyJobs,
+};

--- a/frontend-app/src/types/common.ts
+++ b/frontend-app/src/types/common.ts
@@ -11,4 +11,29 @@ export interface MyProfileDto {
   onboardingStatus?: string;
   referralSource?: string;
   isActive: boolean;
-}   
+}
+
+export interface PropertyDto {
+  id: string;
+  nickname?: string;
+  address?: {
+    line1?: string;
+    line2?: string;
+    city?: string;
+    province?: string;
+    postalCode?: string;
+    country?: string;
+  };
+  contact?: {
+    name?: string;
+    email?: string;
+    phone?: string;
+  };
+}
+
+export interface JobDto {
+  id: string;
+  title?: string;
+  status?: string;
+  quoteStatus?: string;
+}


### PR DESCRIPTION
## Summary
- create service for property APIs
- extend job service for property scoped jobs
- add job & property DTO types
- implement dashboard showing properties and job lists
- add modal form to create jobs from property card

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run stylelint` *(fails: stylelint not found)*


------
https://chatgpt.com/codex/tasks/task_e_6849b5ffe02c8332ad832340a78c65ed