### PR TITLE
Add signup spinner and error banner

### DIFF
--- a/frontend-app/src/components/Spinner.tsx
+++ b/frontend-app/src/components/Spinner.tsx
@@ -1,0 +1,28 @@
+import clsx from 'clsx';
+
+interface SpinnerProps {
+  className?: string;
+}
+
+export const Spinner: React.FC<SpinnerProps> = ({ className }) => (
+  <svg
+    className={clsx('animate-spin h-5 w-5', className)}
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+  >
+    <circle
+      className="opacity-25"
+      cx="12"
+      cy="12"
+      r="10"
+      stroke="currentColor"
+      strokeWidth="4"
+    />
+    <path
+      className="opacity-75"
+      fill="currentColor"
+      d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+    />
+  </svg>
+);


### PR DESCRIPTION
## Summary
- show a spinner when submitting registration
- display an error banner when signup API fails

## Testing
- `npm test`
- `npm run stylelint`


------
https://chatgpt.com/codex/tasks/task_e_6849dcdaf9508332b109ec3545628c46