### PR TITLE
Enhance auth form validation

### DIFF
--- a/frontend-app/src/pages/auth/components/LoginForm.tsx
+++ b/frontend-app/src/pages/auth/components/LoginForm.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useForm } from 'react-hook-form';
 import { Button } from '../../../components/Button';
 import { useAuthStore } from '../../../store/useAuthStore';
 
@@ -7,16 +8,24 @@ interface Props {
 }
 
 const LoginForm = ({ onLoggedIn }: Props) => {
-  const [login, setLogin] = useState('');
-  const [password, setPassword] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const loginFn = useAuthStore((s) => s.login);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  type FormData = {
+    email: string;
+    password: string;
+  };
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>();
+
+  const onSubmit = async (data: FormData) => {
     setSubmitting(true);
     try {
-      await loginFn({ login, password });
+      await loginFn({ login: data.email, password: data.password });
       onLoggedIn();
     } finally {
       setSubmitting(false);
@@ -24,21 +33,45 @@ const LoginForm = ({ onLoggedIn }: Props) => {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <input
-        type="text"
-        value={login}
-        onChange={(e) => setLogin(e.target.value)}
-        placeholder="Email or phone"
-        className="w-full p-3 border rounded-lg"
-      />
-      <input
-        type="password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        placeholder="Password"
-        className="w-full p-3 border rounded-lg"
-      />
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <div>
+        <input
+          type="email"
+          placeholder="Email"
+          {...register('email', {
+            required: 'Email is required',
+            pattern: {
+              value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+              message: 'Enter a valid email',
+            },
+          })}
+          className={`w-full p-3 border rounded-lg ${errors.email ? 'border-red-500' : ''}`}
+        />
+        {errors.email && (
+          <p className="text-red-500 text-sm mt-1">{errors.email.message}</p>
+        )}
+      </div>
+      <div>
+        <input
+          type="password"
+          placeholder="Password"
+          {...register('password', {
+            required: 'Password is required',
+            minLength: {
+              value: 6,
+              message: 'Password must be at least 6 characters',
+            },
+            pattern: {
+              value: /\d/,
+              message: 'Password must contain at least one number',
+            },
+          })}
+          className={`w-full p-3 border rounded-lg ${errors.password ? 'border-red-500' : ''}`}
+        />
+        {errors.password && (
+          <p className="text-red-500 text-sm mt-1">{errors.password.message}</p>
+        )}
+      </div>
       <Button type="submit" className="w-full" disabled={submitting}>
         Login
       </Button>

--- a/frontend-app/src/pages/auth/components/RegisterForm.tsx
+++ b/frontend-app/src/pages/auth/components/RegisterForm.tsx
@@ -26,10 +26,12 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegistered }) => {
   const isEmailValid = (val: string) =>
     /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(val);
 
+  const isPasswordValid = (val: string) => val.length >= 6 && /\d/.test(val);
+
   const isFormValid =
     fullName.trim().length > 0 &&
     isEmailValid(email) &&
-    password.length >= 6;
+    isPasswordValid(password);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -73,7 +75,9 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegistered }) => {
           value={fullName}
           onChange={(e) => setFullName(e.target.value)}
           onBlur={() => handleBlur('fullName')}
-          className="w-full p-3 border rounded-lg"
+          className={`w-full p-3 border rounded-lg ${
+            touched.fullName && !fullName.trim() ? 'border-red-500' : ''
+          }`}
         />
         {touched.fullName && !fullName.trim() && (
           <p className="text-red-500 text-sm mt-1">Full name is required</p>
@@ -86,7 +90,9 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegistered }) => {
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           onBlur={() => handleBlur('email')}
-          className="w-full p-3 border rounded-lg"
+          className={`w-full p-3 border rounded-lg ${
+            touched.email && !isEmailValid(email) ? 'border-red-500' : ''
+          }`}
         />
         {touched.email && !isEmailValid(email) && (
           <p className="text-red-500 text-sm mt-1">Enter a valid email</p>
@@ -99,7 +105,9 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegistered }) => {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           onBlur={() => handleBlur('password')}
-          className="w-full p-3 border rounded-lg pr-20"
+          className={`w-full p-3 border rounded-lg pr-20 ${
+            touched.password && !isPasswordValid(password) ? 'border-red-500' : ''
+          }`}
         />
         <button
           type="button"
@@ -108,8 +116,10 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegistered }) => {
         >
           {showPassword ? 'Hide' : 'Show'}
         </button>
-        {touched.password && password.length < 6 && (
-          <p className="text-red-500 text-sm mt-1">Password must be at least 6 characters</p>
+        {touched.password && !isPasswordValid(password) && (
+          <p className="text-red-500 text-sm mt-1">
+            Password must be at least 6 characters and include a number
+          </p>
         )}
       </div>
       <Button type="submit" className="w-full flex items-center justify-center" disabled={submitting || !isFormValid}>

--- a/frontend-app/src/pages/auth/components/__tests__/RegisterForm.test.tsx
+++ b/frontend-app/src/pages/auth/components/__tests__/RegisterForm.test.tsx
@@ -22,6 +22,12 @@ it('enables submit when form is valid and submits registration', async () => {
     target: { value: 'john@example.com' },
   });
   fireEvent.change(screen.getByPlaceholderText(/password/i), {
+    target: { value: 'secret' },
+  });
+
+  expect(button).toBeDisabled();
+
+  fireEvent.change(screen.getByPlaceholderText(/password/i), {
     target: { value: 'secret123' },
   });
 


### PR DESCRIPTION
## Summary
- validate login form with React Hook Form
- require password to contain numbers on registration
- show red borders for invalid fields
- test for stricter password rules

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run test`
- `npm test` in server

------
https://chatgpt.com/codex/tasks/task_e_6849df44c53c8332b209652558be49ab