### PR TITLE
Improve form layout and accessibility

### DIFF
--- a/frontend-app/src/features/auth/LoginPage.tsx
+++ b/frontend-app/src/features/auth/LoginPage.tsx
@@ -6,9 +6,11 @@ function LoginPage() {
   };
 
   return (
-    <div className="max-w-md mx-auto p-6">
-      <h1 className="text-2xl font-bold text-center mb-6">Login</h1>
-      <LoginForm onLoggedIn={handleLoggedIn} />
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <div className="w-full max-w-md">
+        <h1 className="text-2xl font-bold text-center mb-6">Login</h1>
+        <LoginForm onLoggedIn={handleLoggedIn} />
+      </div>
     </div>
   );
 }

--- a/frontend-app/src/features/dashboard/components/AddJobForm.tsx
+++ b/frontend-app/src/features/dashboard/components/AddJobForm.tsx
@@ -33,24 +33,36 @@ export const AddJobForm = ({ property, onCreated }: Props) => {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4 p-4">
+    <form onSubmit={handleSubmit} className="space-y-4 p-4 max-w-md mx-auto">
       <div className="text-sm text-gray-700">
         Creating job for{' '}
         <strong>{property.nickname || property.address?.line1}</strong>
       </div>
-      <input
-        type="text"
-        value={title}
-        onChange={(e) => setTitle(e.target.value)}
-        placeholder="Job title"
-        className="w-full border p-2 rounded"
-      />
-      <textarea
-        value={description}
-        onChange={(e) => setDescription(e.target.value)}
-        placeholder="Job description"
-        className="w-full border p-2 rounded"
-      />
+      <div className="space-y-1">
+        <label htmlFor="title" className="block text-sm font-medium text-gray-700">
+          Job title
+        </label>
+        <input
+          id="title"
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Job title"
+          className="w-full border p-2 rounded"
+        />
+      </div>
+      <div className="space-y-1">
+        <label htmlFor="description" className="block text-sm font-medium text-gray-700">
+          Job description
+        </label>
+        <textarea
+          id="description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Job description"
+          className="w-full border p-2 rounded"
+        />
+      </div>
       <Button type="submit" disabled={submitting || !title}>
         Create Job
       </Button>

--- a/frontend-app/src/features/leadgen/QuickWizard.tsx
+++ b/frontend-app/src/features/leadgen/QuickWizard.tsx
@@ -125,9 +125,12 @@ export const QuickWizard = ({ onStart, onComplete }: Props) => {
         <motion.section layout className="space-y-4">
           <h3 className="font-semibold mb-3">Just a few details</h3>
           {questions[subcategory.name]?.map((q, i) => (
-            <div key={i}>
-              <label className="text-sm font-medium">{q}</label>
+            <div key={i} className="space-y-1">
+              <label htmlFor={`q${i}`} className="text-sm font-medium">
+                {q}
+              </label>
               <input
+                id={`q${i}`}
                 type="text"
                 value={answers[q] || ''}
                 onChange={(e) => setAnswers({ ...answers, [q]: e.target.value })}
@@ -136,8 +139,11 @@ export const QuickWizard = ({ onStart, onComplete }: Props) => {
             </div>
           ))}
           <div>
-            <label className="text-sm font-medium">Anything else we should know?</label>
+            <label htmlFor="notes" className="text-sm font-medium">
+              Anything else we should know?
+            </label>
             <textarea
+              id="notes"
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
               className="w-full border p-2 rounded"
@@ -150,8 +156,11 @@ export const QuickWizard = ({ onStart, onComplete }: Props) => {
 
       {step === 3 && (
         <motion.section layout className="space-y-4">
-          <label className="block text-sm font-medium">Your location (Postcode)</label>
+          <label htmlFor="postcode" className="block text-sm font-medium">
+            Your location (Postcode)
+          </label>
           <input
+            id="postcode"
             type="text"
             value={postcode}
             onChange={(e) => setPostcode(e.target.value)}
@@ -164,8 +173,11 @@ export const QuickWizard = ({ onStart, onComplete }: Props) => {
 
       {step === 4 && (
         <motion.section layout className="space-y-4">
-          <label className="block text-sm font-medium">When do you need the service?</label>
+          <label htmlFor="needDate" className="block text-sm font-medium">
+            When do you need the service?
+          </label>
           <input
+            id="needDate"
             type="date"
             value={date}
             onChange={(e) => setDate(e.target.value)}
@@ -188,15 +200,21 @@ export const QuickWizard = ({ onStart, onComplete }: Props) => {
 
       {step === 5 && (
         <motion.section layout className="space-y-4">
-          <label className="block text-sm font-medium">Your Email</label>
+          <label htmlFor="email" className="block text-sm font-medium">
+            Your Email
+          </label>
           <input
+            id="email"
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             className="w-full border p-2 rounded"
           />
-          <label className="block text-sm font-medium">Phone (optional)</label>
+          <label htmlFor="phone" className="block text-sm font-medium">
+            Phone (optional)
+          </label>
           <input
+            id="phone"
             type="tel"
             value={phone}
             onChange={(e) => setPhone(e.target.value)}

--- a/frontend-app/src/pages/auth/components/LoginForm.tsx
+++ b/frontend-app/src/pages/auth/components/LoginForm.tsx
@@ -33,9 +33,13 @@ const LoginForm = ({ onLoggedIn }: Props) => {
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-      <div>
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 max-w-md mx-auto">
+      <div className="space-y-1">
+        <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+          Email
+        </label>
         <input
+          id="email"
           type="email"
           placeholder="Email"
           {...register('email', {
@@ -51,8 +55,12 @@ const LoginForm = ({ onLoggedIn }: Props) => {
           <p className="text-red-500 text-sm mt-1">{errors.email.message}</p>
         )}
       </div>
-      <div>
+      <div className="space-y-1">
+        <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+          Password
+        </label>
         <input
+          id="password"
           type="password"
           placeholder="Password"
           {...register('password', {

--- a/frontend-app/src/pages/auth/components/OtpForm.tsx
+++ b/frontend-app/src/pages/auth/components/OtpForm.tsx
@@ -21,16 +21,22 @@ export const OtpForm = ({ userId, onVerified }: Props) => {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <input
-        type="text"
-        inputMode="numeric"
-        maxLength={6}
-        value={otp}
-        onChange={(e) => setOtp(e.target.value)}
-        className="w-full p-3 rounded-lg border text-center tracking-widest text-xl"
-        placeholder="Enter 6-digit code"
-      />
+    <form onSubmit={handleSubmit} className="space-y-4 max-w-sm mx-auto">
+      <div className="space-y-1">
+        <label htmlFor="otp" className="block text-sm font-medium text-gray-700">
+          Verification code
+        </label>
+        <input
+          id="otp"
+          type="text"
+          inputMode="numeric"
+          maxLength={6}
+          value={otp}
+          onChange={(e) => setOtp(e.target.value)}
+          className="w-full p-3 rounded-lg border text-center tracking-widest text-xl"
+          placeholder="Enter 6-digit code"
+        />
+      </div>
       <Button type="submit" className="w-full" disabled={submitting}>
         Verify
       </Button>

--- a/frontend-app/src/pages/auth/components/RegisterForm.tsx
+++ b/frontend-app/src/pages/auth/components/RegisterForm.tsx
@@ -63,14 +63,18 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegistered }) => {
   return submitted ? (
     <div className="text-center text-primary">OTP sent! Please verify.</div>
   ) : (
-    <form onSubmit={handleSubmit} className="space-y-4">
+    <form onSubmit={handleSubmit} className="space-y-4 max-w-md mx-auto">
       {error && (
         <div className="bg-red-100 text-red-700 p-2 rounded text-sm" role="alert">
           {error}
         </div>
       )}
-      <div>
+      <div className="space-y-1">
+        <label htmlFor="fullName" className="block text-sm font-medium text-gray-700">
+          Full name
+        </label>
         <input
+          id="fullName"
           type="text"
           placeholder="Full name"
           value={fullName}
@@ -84,8 +88,12 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegistered }) => {
           <p className="text-red-500 text-sm mt-1">Full name is required</p>
         )}
       </div>
-      <div>
+      <div className="space-y-1">
+        <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+          Email address
+        </label>
         <input
+          id="email"
           type="email"
           placeholder="Email address"
           value={email}
@@ -99,8 +107,12 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegistered }) => {
           <p className="text-red-500 text-sm mt-1">Enter a valid email</p>
         )}
       </div>
-      <div className="relative">
+      <div className="relative space-y-1">
+        <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+          Password
+        </label>
         <input
+          id="password"
           type={showPassword ? 'text' : 'password'}
           placeholder="Password"
           value={password}

--- a/frontend-app/src/screens/RegisterScreen.tsx
+++ b/frontend-app/src/screens/RegisterScreen.tsx
@@ -16,10 +16,14 @@ export const RegisterScreen = () => {
   };
 
   return (
-    <div className="max-w-md mx-auto p-6">
-      <h1 className="text-2xl font-bold text-center mb-6">Join CheckTrade</h1>
-      {step === 'register' && <RegisterForm onRegistered={handleRegisterSuccess} />}
-      {step === 'verify' && userId && <OtpForm userId={userId} onVerified={handleVerifySuccess} />}
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <div className="w-full max-w-md">
+        <h1 className="text-2xl font-bold text-center mb-6">Join CheckTrade</h1>
+        {step === 'register' && <RegisterForm onRegistered={handleRegisterSuccess} />}
+        {step === 'verify' && userId && (
+          <OtpForm userId={userId} onVerified={handleVerifySuccess} />
+        )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- center login and register pages for mobile-friendly layout
- add labels and responsive styling to login, register, and OTP forms
- add labels and centering to Add Job form
- ensure lead generation wizard fields have labels

## Testing
- `npm test` in `frontend-app`
- `npm test` in `server`
- `npm run lint` *(fails: 770 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6849e067201083329acc02522c81309a