### PR TITLE
Update registration fields

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -8,12 +8,15 @@ const users = [];
 const jobs = [];
 
 app.post('/api/identity/register', (req, res) => {
-  const { login } = req.body;
-  if (!login) {
-    return res.status(400).json({ error: 'login required' });
+  const { fullName, email, password } = req.body;
+
+  if (!fullName || !email || !password) {
+    return res.status(400).json({ error: 'fullName, email, and password required' });
   }
-  const user = { id: uuidv4(), login };
+
+  const user = { id: uuidv4(), fullName, email, password };
   users.push(user);
+
   res.status(201).json({ userId: user.id });
 });
 

--- a/server/tests/server.test.js
+++ b/server/tests/server.test.js
@@ -8,18 +8,30 @@ describe('API', () => {
   });
 
   test('register user', async () => {
+    const payload = {
+      fullName: 'Test User',
+      email: 'test@example.com',
+      password: 'secret123',
+    };
+
     const res = await request(app)
       .post('/api/identity/register')
-      .send({ login: 'test@example.com' });
+      .send(payload);
+
     expect(res.status).toBe(201);
     expect(res.body.userId).toBeDefined();
     expect(users.length).toBe(1);
+    expect(users[0]).toMatchObject(payload);
   });
 
   test('create job for user', async () => {
     const userRes = await request(app)
       .post('/api/identity/register')
-      .send({ login: 'job@example.com' });
+      .send({
+        fullName: 'Job User',
+        email: 'job@example.com',
+        password: 'secret123',
+      });
     const userId = userRes.body.userId;
     const jobRes = await request(app)
       .post(`/api/users/${userId}/jobs`)


### PR DESCRIPTION
## Summary
- support `fullName`, `email`, and `password` when registering a user
- expect these fields in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849e281a6b483328ef2328afa697a1d