### PR TITLE
Add login link under register form

### DIFF
--- a/frontend-app/src/pages/auth/components/RegisterForm.tsx
+++ b/frontend-app/src/pages/auth/components/RegisterForm.tsx
@@ -147,6 +147,12 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegistered }) => {
         <FcGoogle size={20} />
         <span className="text-sm font-medium text-gray-800">Continue with Google</span>
       </button>
+      <p className="text-center text-sm text-gray-600">
+        Already have an account?{' '}
+        <a href="/login" className="underline text-primary">
+          Log in
+        </a>
+      </p>
     </form>
   );
 };


### PR DESCRIPTION
## Summary
- add a login text link below the Google sign-up button

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6849e470f4288332a54594c3ca012f7d