### PR TITLE
Update registration payload

### DIFF
--- a/frontend-app/src/api/identityApi.ts
+++ b/frontend-app/src/api/identityApi.ts
@@ -1,13 +1,9 @@
 import http from './httpClient';
 
 export interface RegisterRequest {
-  login: string;
-  userType: string;
-  tenantId: string;
-  mobile?: string;
-  email?: string;
-  preferredLanguage? : string;
-  referralSource? : string
+  fullName: string;
+  email: string;
+  password: string;
 }
 
 export interface VerifyOtpRequest {

--- a/frontend-app/src/pages/auth/components/RegisterForm.tsx
+++ b/frontend-app/src/pages/auth/components/RegisterForm.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { Spinner } from '../../../components/Spinner';
-import { v4 as uuidv4 } from 'uuid'; // If you want to simulate a tenantId
 import { Button } from '../../../components/Button';
 import { useAuthStore } from '../../../store/useAuthStore';
 import { FcGoogle } from 'react-icons/fc';
@@ -40,11 +39,9 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegistered }) => {
     setSubmitting(true);
     try {
       const userId = await register({
-        login: email,
-        userType: 'Customer',
-        tenantId: uuidv4(), // Replace with real tenant ID
-        preferredLanguage: 'en',
-        referralSource: 'Website',
+        fullName,
+        email,
+        password,
       });
 
       onRegistered(userId);

--- a/frontend-app/src/store/useAuthStore.ts
+++ b/frontend-app/src/store/useAuthStore.ts
@@ -35,7 +35,11 @@ export const useAuthStore = create<AuthState>((set) => ({
 register: async (req) => {
   try {
     set({ loading: true });
-    const { data } = await registerUser(req);
+    const { data } = await registerUser({
+      fullName: req.fullName,
+      email: req.email,
+      password: req.password,
+    });
     return data.userId; // 👈 Bubble this up
   } catch (err: any) {
     set({ error: err.message });


### PR DESCRIPTION
## Summary
- change `registerUser` to accept `fullName`, `email` and `password`
- send the new payload from `useAuthStore`
- adjust registration form submission

## Testing
- `npx vitest run --silent`
- `npm test --silent` in `server`

------
https://chatgpt.com/codex/tasks/task_e_684a8771605c8332a2b0a6013f3a1e0d