### PR TITLE
Add email verification screen

### DIFF
--- a/frontend-app/src/features/auth/EmailVerificationPage.tsx
+++ b/frontend-app/src/features/auth/EmailVerificationPage.tsx
@@ -1,0 +1,16 @@
+import { useSearchParams } from 'react-router-dom';
+import EmailVerificationScreen from '../../screens/EmailVerificationScreen';
+
+const EmailVerificationPage = () => {
+  const [params] = useSearchParams();
+  const uid = params.get('uid') || '';
+  const email = params.get('email') || '';
+
+  if (!uid || !email) {
+    return <div className="p-4 text-center">Missing verification info.</div>;
+  }
+
+  return <EmailVerificationScreen userId={uid} email={email} />;
+};
+
+export default EmailVerificationPage;

--- a/frontend-app/src/main.tsx
+++ b/frontend-app/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import LoginPage from './features/auth/LoginPage';
 import SignupPage from './features/auth/SignupPage';
+import EmailVerificationPage from './features/auth/EmailVerificationPage';
 import Dashboard from './features/dashboard/Dashboard';
 import './index.css';
 import HomePage from './pages/Home/HomePage';
@@ -21,6 +22,7 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
             <Route path="/login" element={<LoginPage />} />
             <Route path="/signup" element={<SignupPage />} />
             <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/verify-email" element={<EmailVerificationPage />} />
             <Route path="/job/new" element={<NewJobPage />} />
           </Route>
         </Routes>

--- a/frontend-app/src/pages/auth/components/RegisterForm.tsx
+++ b/frontend-app/src/pages/auth/components/RegisterForm.tsx
@@ -5,7 +5,7 @@ import { useAuthStore } from '../../../store/useAuthStore';
 import { FcGoogle } from 'react-icons/fc';
 
 interface RegisterFormProps {
-  onRegistered: (userId: string) => void;
+  onRegistered: (userId: string, email: string) => void;
 }
 
 export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegistered }) => {
@@ -44,7 +44,7 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegistered }) => {
         password,
       });
 
-      onRegistered(userId);
+      onRegistered(userId, email);
       setSubmitted(true);
     } catch (err: any) {
       const message = err?.response?.data?.message || err.message || 'Registration failed';

--- a/frontend-app/src/pages/auth/components/__tests__/RegisterForm.test.tsx
+++ b/frontend-app/src/pages/auth/components/__tests__/RegisterForm.test.tsx
@@ -34,7 +34,9 @@ it('enables submit when form is valid and submits registration', async () => {
   expect(button).not.toBeDisabled();
   fireEvent.submit(button);
 
-  await waitFor(() => expect(onRegistered).toHaveBeenCalledWith('user1'));
+  await waitFor(() =>
+    expect(onRegistered).toHaveBeenCalledWith('user1', 'john@example.com')
+  );
 });
 
 it('shows validation errors on blur when fields are invalid', async () => {
@@ -82,6 +84,8 @@ it('disables submit while submitting and triggers success callback', async () =>
 
   expect(button).toBeDisabled();
 
-  await waitFor(() => expect(onRegistered).toHaveBeenCalledWith('user1'));
+  await waitFor(() =>
+    expect(onRegistered).toHaveBeenCalledWith('user1', 'john@example.com')
+  );
   expect(screen.getByText(/otp sent/i)).toBeInTheDocument();
 });

--- a/frontend-app/src/screens/EmailVerificationScreen.tsx
+++ b/frontend-app/src/screens/EmailVerificationScreen.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react';
+import { MailCheck } from 'lucide-react';
+import { Button } from '../components/Button';
+import { useAuthStore } from '../store/useAuthStore';
+import { Spinner } from '../components/Spinner';
+import { useNavigate } from 'react-router-dom';
+
+interface Props {
+  userId: string;
+  email: string;
+}
+
+export const EmailVerificationScreen = ({ userId, email }: Props) => {
+  const resend = useAuthStore((s) => s.resend);
+  const fetchProfile = useAuthStore((s) => s.fetchProfile);
+  const profile = useAuthStore((s) => s.profile);
+  const navigate = useNavigate();
+
+  const [verified, setVerified] = useState(profile?.isActive ?? false);
+  const [resending, setResending] = useState(false);
+
+  useEffect(() => {
+    if (verified) return;
+    const interval = setInterval(async () => {
+      await fetchProfile();
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [verified, fetchProfile]);
+
+  useEffect(() => {
+    if (profile?.isActive) {
+      setVerified(true);
+    }
+  }, [profile]);
+
+  const handleResend = async () => {
+    setResending(true);
+    try {
+      await resend({ userId });
+    } finally {
+      setResending(false);
+    }
+  };
+
+  const handleContinue = () => {
+    navigate('/dashboard');
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <div className="w-full max-w-md space-y-6 text-center">
+        <MailCheck className="w-16 h-16 mx-auto text-primary" />
+        <p className="text-lg">
+          Please verify your email – we&apos;ve sent a confirmation link to {email}
+        </p>
+        <div className="space-y-2">
+          <Button onClick={handleResend} disabled={resending} variant="outline" className="w-full">
+            {resending ? (
+              <span className="flex items-center justify-center gap-2"><Spinner className="text-primary" /> Resending…</span>
+            ) : (
+              'Resend Email'
+            )}
+          </Button>
+          <button
+            type="button"
+            onClick={() => navigate('/signup')}
+            className="block mx-auto text-sm underline text-primary"
+          >
+            Change Email
+          </button>
+        </div>
+        <Button onClick={handleContinue} disabled={!verified} className="w-full">
+          Continue
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default EmailVerificationScreen;

--- a/frontend-app/src/screens/RegisterScreen.tsx
+++ b/frontend-app/src/screens/RegisterScreen.tsx
@@ -1,28 +1,17 @@
-import { useState } from 'react';
-import { OtpForm } from '../pages/auth/components/OtpForm';
 import { RegisterForm } from '../pages/auth/components/RegisterForm';
-
+import { useNavigate } from 'react-router-dom';
 export const RegisterScreen = () => {
-  const [userId, setUserId] = useState<string | null>(null);
-  const [step, setStep] = useState<'register' | 'verify'>('register');
+  const navigate = useNavigate();
 
-  const handleRegisterSuccess = (id: string) => {
-    setUserId(id);
-    setStep('verify');
-  };
-
-  const handleVerifySuccess = () => {
-    window.location.href = '/dashboard';
+  const handleRegisterSuccess = (id: string, email: string) => {
+    navigate(`/verify-email?uid=${id}&email=${encodeURIComponent(email)}`);
   };
 
   return (
     <div className="min-h-screen flex items-center justify-center p-4">
       <div className="w-full max-w-md">
         <h1 className="text-2xl font-bold text-center mb-6">Join CheckTrade</h1>
-        {step === 'register' && <RegisterForm onRegistered={handleRegisterSuccess} />}
-        {step === 'verify' && userId && (
-          <OtpForm userId={userId} onVerified={handleVerifySuccess} />
-        )}
+        <RegisterForm onRegistered={handleRegisterSuccess} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- route and component to verify email
- screen for prompting users to confirm email and resend link
- pass email back from RegisterForm
- redirect RegisterScreen to the new verification page
- adjust tests for new RegisterForm behaviour

## Testing
- `npm --prefix frontend-app run lint` *(fails: ESLint couldn't find config)*
- `npm --prefix frontend-app run stylelint` *(fails: stylelint not found)*
- `npm --prefix frontend-app run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a893fc9a88332ac041304cf5fb501