### PR TITLE
Fix object URL leak in profile setup

### DIFF
--- a/frontend-app/src/features/dashboard/components/__tests__/AddJobForm.test.tsx
+++ b/frontend-app/src/features/dashboard/components/__tests__/AddJobForm.test.tsx
@@ -2,15 +2,17 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import AddJobForm from '../AddJobForm';
 
-let createJobMock: any;
-vi.mock('../../../../services/jobService', () => {
-  createJobMock = vi.fn().mockResolvedValue({});
-  return { default: { createJob: createJobMock } };
-});
+vi.mock('../../../../services/jobService', () => ({
+  default: { createJob: vi.fn() },
+}));
+
+import jobService from '../../../../services/jobService';
+const createJobMock = vi.mocked(jobService.createJob);
 
 const property = { id: 'p1', nickname: 'Home' } as any;
 
 it('creates job', async () => {
+  createJobMock.mockResolvedValue({});
   const onCreated = vi.fn();
   render(<AddJobForm property={property} onCreated={onCreated} />);
 

--- a/frontend-app/src/features/onboarding/ProfileSetupPage.tsx
+++ b/frontend-app/src/features/onboarding/ProfileSetupPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Button } from '../../components/Button';
@@ -22,6 +22,7 @@ export default function ProfileSetupPage() {
   const [city, setCity] = useState('');
   const [postalCode, setPostalCode] = useState('');
   const [photo, setPhoto] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [submitting, setSubmitting] = useState(false);
   const fileRef = useRef<HTMLInputElement>(null);
@@ -68,6 +69,20 @@ export default function ProfileSetupPage() {
     const f = e.target.files && e.target.files[0];
     if (f) setPhoto(f);
   };
+
+  useEffect(() => {
+    if (!photo) {
+      setPreviewUrl(null);
+      return;
+    }
+
+    const url = URL.createObjectURL(photo);
+    setPreviewUrl(url);
+
+    return () => {
+      URL.revokeObjectURL(url);
+    };
+  }, [photo]);
 
   const next = () => {
     if (step === 1 && validateStep1()) setStep(2);
@@ -255,9 +270,9 @@ export default function ProfileSetupPage() {
                   className="hidden"
                 />
                 <div className="mx-auto h-24 w-24 overflow-hidden rounded-full bg-gray-200">
-                  {photo && (
+                  {photo && previewUrl && (
                     <img
-                      src={URL.createObjectURL(photo)}
+                      src={previewUrl}
                       alt="Preview"
                       className="h-full w-full object-cover"
                     />


### PR DESCRIPTION
## Summary
- clean up object URLs when profile photo changes in `ProfileSetupPage`
- update AddJobForm test mocking

## Testing
- `npm run lint`
- `npm run stylelint`
- `npm test`
- `npm test` in `server/`

------
https://chatgpt.com/codex/tasks/task_e_684a9e97fe0c8332a17eb5509c064e36