### PR TITLE
Fix httpClient export order

### DIFF
--- a/frontend-app/src/api/httpClient.ts
+++ b/frontend-app/src/api/httpClient.ts
@@ -1,6 +1,3 @@
-
-export default httpClient;
-
 import axios from 'axios';
 
 const httpClient = axios.create({


### PR DESCRIPTION
## Summary
- remove duplicate early export of `httpClient` so default export occurs after the client is defined

## Testing
- `npm test` in `frontend-app`
- `npm test` in `server`


------
https://chatgpt.com/codex/tasks/task_e_684aa0543e0083329e8e8f72cad741be