### PR TITLE
Fix profile update request

### DIFF
--- a/frontend-app/src/api/httpClient.ts
+++ b/frontend-app/src/api/httpClient.ts
@@ -17,4 +17,3 @@ httpClient.interceptors.response.use(
 );
 
 export default httpClient;
-

--- a/frontend-app/src/features/onboarding/ProfileSetupPage.tsx
+++ b/frontend-app/src/features/onboarding/ProfileSetupPage.tsx
@@ -28,7 +28,7 @@ export default function ProfileSetupPage() {
   const [submitting, setSubmitting] = useState(false);
   const fileRef = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
-  const profile = useAuthStore((s) => s.profile);
+  const userId = useAuthStore((s) => s.profile?.userId);
 
   const phoneDigits = phone.replace(/\D/g, '').slice(0, 10);
   const isPhoneValid = phoneDigits.length === 10;
@@ -97,7 +97,7 @@ export default function ProfileSetupPage() {
     setSubmitting(true);
     try {
       await profileService.updateProfile({
-        userId: profile?.userId || '',
+        userId: userId || '',
         firstName,
         lastName,
         phone: phoneDigits,

--- a/frontend-app/src/services/profileService.ts
+++ b/frontend-app/src/services/profileService.ts
@@ -10,6 +10,6 @@ export interface ProfileSetupData {
 }
 
 const updateProfile = (data: ProfileSetupData) =>
-  http.post('/api/identity/profile', data);
+  http.post('/api/identity/profile', { userId: data.userId, ...data });
 
 export default { updateProfile };


### PR DESCRIPTION
## Summary
- include userId when calling the profile API
- plumb userId from auth store to the profile wizard
- clean up httpClient trailing newline

## Testing
- `npm run lint`
- `npm run stylelint`
- `npm run test`
- `npm test` in server

------
https://chatgpt.com/codex/tasks/task_e_684aa78a0c2483328ed8658e0b267e1b