### PR TITLE
Add profile completion banner on Dashboard

### DIFF
--- a/frontend-app/src/features/dashboard/Dashboard.tsx
+++ b/frontend-app/src/features/dashboard/Dashboard.tsx
@@ -1,11 +1,17 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import propertyService, { Property } from '../../services/propertyService';
 import PropertyCard from './components/PropertyCard';
 import AddJobModal from './components/AddJobModal';
+import { useAuthStore } from '../../store/useAuthStore';
+import { Button } from '../../components/Button';
 
 function Dashboard() {
   const [properties, setProperties] = useState<Property[]>([]);
   const [selected, setSelected] = useState<Property | null>(null);
+  const profile = useAuthStore((s) => s.profile);
+
+  const showBanner = profile && !profile.isOnboarded;
 
   useEffect(() => {
     propertyService
@@ -16,6 +22,16 @@ function Dashboard() {
 
   return (
     <div className="mx-auto max-w-3xl p-4">
+      {showBanner && (
+        <div className="mb-4 flex items-center justify-between rounded border border-primary bg-white p-3 shadow-sm">
+          <span className="text-sm">Complete your profile to continue</span>
+          <Link to="/profile-setup">
+            <Button variant="outline" className="text-sm">
+              Complete profile
+            </Button>
+          </Link>
+        </div>
+      )}
       <h1 className="mb-4 text-2xl font-bold">My Properties</h1>
       {properties.map((p) => (
         <PropertyCard key={p.id} property={p} onAddJob={setSelected} />

--- a/frontend-app/src/features/dashboard/__tests__/Dashboard.test.tsx
+++ b/frontend-app/src/features/dashboard/__tests__/Dashboard.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import Dashboard from '../Dashboard';
+
+let profile: any;
+
+vi.mock('../../../store/useAuthStore', () => ({
+  useAuthStore: (selector: any) => selector({ profile }),
+}));
+
+vi.mock('../../../services/propertyService', () => ({
+  default: { getProperties: vi.fn() },
+}));
+
+import propertyService from '../../../services/propertyService';
+const getPropertiesMock = vi.mocked(propertyService.getProperties);
+
+beforeEach(() => {
+  getPropertiesMock.mockResolvedValue({ data: [] });
+});
+
+test('shows banner when profile is not onboarded', async () => {
+  profile = { isOnboarded: false };
+  render(
+    <MemoryRouter>
+      <Dashboard />
+    </MemoryRouter>,
+  );
+  await waitFor(() => {
+    expect(
+      screen.getByRole('button', { name: /complete profile/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+test('hides banner when profile is onboarded', async () => {
+  profile = { isOnboarded: true };
+  render(
+    <MemoryRouter>
+      <Dashboard />
+    </MemoryRouter>,
+  );
+  await waitFor(() => {
+    expect(
+      screen.queryByRole('button', { name: /complete profile/i }),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- show onboarding banner when the user has not finished profile setup
- link banner button to profile setup screen
- unit test banner visibility logic

## Testing
- `npm test --prefix frontend-app`

------
https://chatgpt.com/codex/tasks/task_e_684aaf0b3c548332a62185747c9ce7b7