### PR TITLE
Improve ARIA errors on auth forms

### DIFF
--- a/frontend-app/src/pages/auth/components/LoginForm.tsx
+++ b/frontend-app/src/pages/auth/components/LoginForm.tsx
@@ -48,6 +48,8 @@ const LoginForm = ({ onLoggedIn }: Props) => {
           id="email"
           type="email"
           placeholder="Email"
+          aria-describedby={errors.email ? 'login-email-error' : undefined}
+          aria-invalid={errors.email ? 'true' : undefined}
           {...register('email', {
             required: 'Email is required',
             pattern: {
@@ -58,7 +60,11 @@ const LoginForm = ({ onLoggedIn }: Props) => {
           className={`w-full rounded-lg border p-3 ${errors.email ? 'border-red-500' : ''}`}
         />
         {errors.email && (
-          <p className="mt-1 text-sm text-red-500">{errors.email.message}</p>
+          <div aria-live="assertive">
+            <p id="login-email-error" className="mt-1 text-sm text-red-500">
+              {errors.email.message}
+            </p>
+          </div>
         )}
       </div>
       <div className="space-y-1">
@@ -72,6 +78,10 @@ const LoginForm = ({ onLoggedIn }: Props) => {
           id="password"
           type="password"
           placeholder="Password"
+          aria-describedby={
+            errors.password ? 'login-password-error' : undefined
+          }
+          aria-invalid={errors.password ? 'true' : undefined}
           {...register('password', {
             required: 'Password is required',
             minLength: {
@@ -86,7 +96,11 @@ const LoginForm = ({ onLoggedIn }: Props) => {
           className={`w-full rounded-lg border p-3 ${errors.password ? 'border-red-500' : ''}`}
         />
         {errors.password && (
-          <p className="mt-1 text-sm text-red-500">{errors.password.message}</p>
+          <div aria-live="assertive">
+            <p id="login-password-error" className="mt-1 text-sm text-red-500">
+              {errors.password.message}
+            </p>
+          </div>
         )}
       </div>
       <Button type="submit" className="w-full" disabled={submitting}>

--- a/frontend-app/src/pages/auth/components/RegisterForm.tsx
+++ b/frontend-app/src/pages/auth/components/RegisterForm.tsx
@@ -84,6 +84,14 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegistered }) => {
             value={fullName}
             onChange={(e) => setFullName(e.target.value)}
             onBlur={() => handleBlur('fullName')}
+            aria-describedby={
+              touched.fullName && !fullName.trim()
+                ? 'register-fullname-error'
+                : undefined
+            }
+            aria-invalid={
+              touched.fullName && !fullName.trim() ? 'true' : undefined
+            }
             className={`w-full rounded-md border p-3 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary ${
               touched.fullName && !fullName.trim()
                 ? 'border-error text-error'
@@ -91,9 +99,14 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegistered }) => {
             }`}
           />
           {touched.fullName && !fullName.trim() && (
-            <p className="mt-1 text-sm italic text-error transition-opacity">
-              Full name is required
-            </p>
+            <div aria-live="assertive">
+              <p
+                id="register-fullname-error"
+                className="mt-1 text-sm italic text-error transition-opacity"
+              >
+                Full name is required
+              </p>
+            </div>
           )}
         </div>
         <div className="space-y-1">
@@ -110,6 +123,14 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegistered }) => {
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             onBlur={() => handleBlur('email')}
+            aria-describedby={
+              touched.email && !isEmailValid(email)
+                ? 'register-email-error'
+                : undefined
+            }
+            aria-invalid={
+              touched.email && !isEmailValid(email) ? 'true' : undefined
+            }
             className={`w-full rounded-md border p-3 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary ${
               touched.email && !isEmailValid(email)
                 ? 'border-error text-error'
@@ -117,9 +138,14 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegistered }) => {
             }`}
           />
           {touched.email && !isEmailValid(email) && (
-            <p className="mt-1 text-sm italic text-error transition-opacity">
-              Enter a valid email
-            </p>
+            <div aria-live="assertive">
+              <p
+                id="register-email-error"
+                className="mt-1 text-sm italic text-error transition-opacity"
+              >
+                Enter a valid email
+              </p>
+            </div>
           )}
         </div>
         <div className="relative space-y-1">
@@ -136,6 +162,16 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegistered }) => {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             onBlur={() => handleBlur('password')}
+            aria-describedby={
+              touched.password && !isPasswordValid(password)
+                ? 'register-password-error'
+                : undefined
+            }
+            aria-invalid={
+              touched.password && !isPasswordValid(password)
+                ? 'true'
+                : undefined
+            }
             className={`w-full rounded-md border p-3 pr-20 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary ${
               touched.password && !isPasswordValid(password)
                 ? 'border-error text-error'
@@ -150,9 +186,14 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegistered }) => {
             {showPassword ? 'Hide' : 'Show'}
           </button>
           {touched.password && !isPasswordValid(password) && (
-            <p className="mt-1 text-sm italic text-error transition-opacity">
-              Password must be at least 6 characters and include a number
-            </p>
+            <div aria-live="assertive">
+              <p
+                id="register-password-error"
+                className="mt-1 text-sm italic text-error transition-opacity"
+              >
+                Password must be at least 6 characters and include a number
+              </p>
+            </div>
           )}
           <p className="text-xs text-gray-500">
             8+ characters, at least one number

--- a/frontend-app/src/pages/auth/components/__tests__/RegisterForm.test.tsx
+++ b/frontend-app/src/pages/auth/components/__tests__/RegisterForm.test.tsx
@@ -69,6 +69,49 @@ it('shows validation errors on blur when fields are invalid', async () => {
   expect(screen.getByRole('button', { name: /sign up/i })).toBeDisabled();
 });
 
+it('applies ARIA attributes to invalid fields', async () => {
+  render(<RegisterForm onRegistered={() => {}} />);
+
+  fireEvent.blur(screen.getByLabelText(/full name/i));
+  const fullNameError = await screen.findByText(/full name is required/i);
+  const fullNameInput = screen.getByLabelText(/full name/i);
+  expect(fullNameInput).toHaveAttribute('aria-invalid', 'true');
+  expect(fullNameInput).toHaveAttribute(
+    'aria-describedby',
+    'register-fullname-error',
+  );
+  expect(fullNameError).toHaveAttribute('id', 'register-fullname-error');
+  expect(fullNameError.parentElement).toHaveAttribute('aria-live', 'assertive');
+
+  fireEvent.change(screen.getByLabelText(/email address/i), {
+    target: { value: 'invalid' },
+  });
+  fireEvent.blur(screen.getByLabelText(/email address/i));
+  const emailError = await screen.findByText(/enter a valid email/i);
+  const emailInput = screen.getByLabelText(/email address/i);
+  expect(emailInput).toHaveAttribute('aria-invalid', 'true');
+  expect(emailInput).toHaveAttribute(
+    'aria-describedby',
+    'register-email-error',
+  );
+  expect(emailError).toHaveAttribute('id', 'register-email-error');
+
+  fireEvent.change(screen.getByLabelText(/password/i), {
+    target: { value: 'short' },
+  });
+  fireEvent.blur(screen.getByLabelText(/password/i));
+  const passwordError = await screen.findByText(
+    /password must be at least 6 characters/i,
+  );
+  const passwordInput = screen.getByLabelText(/^password$/i);
+  expect(passwordInput).toHaveAttribute('aria-invalid', 'true');
+  expect(passwordInput).toHaveAttribute(
+    'aria-describedby',
+    'register-password-error',
+  );
+  expect(passwordError).toHaveAttribute('id', 'register-password-error');
+});
+
 it('disables submit while submitting and navigates on success', async () => {
   const registerPromise = new Promise<string>((res) =>
     setTimeout(() => res('user1'), 10),


### PR DESCRIPTION
## Summary
- improve Login and Register forms accessibility with aria-describedby and aria-invalid
- wrap field error messages in an assertive live region
- test that ARIA attributes are wired up correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ab0d056b08332859f512537c64b79