### PR TITLE
Handle profile update failure with toast

### DIFF
--- a/frontend-app/src/features/onboarding/ProfileSetupPage.tsx
+++ b/frontend-app/src/features/onboarding/ProfileSetupPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Button } from '../../components/Button';
 import { Spinner } from '../../components/Spinner';
+import Toast from '../../components/Toast';
 import profileService from '../../services/profileService';
 import { useAuthStore } from '../../store/useAuthStore';
 
@@ -34,6 +35,7 @@ export default function ProfileSetupPage() {
   const cityRef = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
   const userId = useAuthStore((s) => s.profile?.userId);
+  const [toastMessage, setToastMessage] = useState('');
 
   const phoneDigits = phone.replace(/\D/g, '').slice(0, 10);
   const isPhoneValid = phoneDigits.length === 10;
@@ -109,7 +111,10 @@ export default function ProfileSetupPage() {
         lastName: lastNameRef,
         phone: phoneRef,
       };
-      map[first]?.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      map[first]?.current?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+      });
     }
   };
 
@@ -123,7 +128,10 @@ export default function ProfileSetupPage() {
         city: cityRef,
         photo: fileRef,
       };
-      map[first]?.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      map[first]?.current?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+      });
       return;
     }
     setSubmitting(true);
@@ -137,8 +145,10 @@ export default function ProfileSetupPage() {
         postalCode,
       });
       navigate('/dashboard');
-    } catch {
-      setErrors({ finish: 'Could not save profile, try again' });
+    } catch (err: any) {
+      const message = err?.message || 'Could not save profile, try again';
+      setErrors({ finish: message });
+      setToastMessage(message);
     } finally {
       setSubmitting(false);
     }
@@ -360,6 +370,9 @@ export default function ProfileSetupPage() {
           )}
         </AnimatePresence>
       </div>
+      {toastMessage && (
+        <Toast message={toastMessage} onDismiss={() => setToastMessage('')} />
+      )}
     </div>
   );
 }

--- a/frontend-app/src/features/onboarding/__tests__/ProfileSetupPage.test.tsx
+++ b/frontend-app/src/features/onboarding/__tests__/ProfileSetupPage.test.tsx
@@ -11,6 +11,9 @@ vi.mock('../../../services/profileService', () => ({
   default: { updateProfile: vi.fn() },
 }));
 
+import profileService from '../../../services/profileService';
+const updateProfileMock = vi.mocked(profileService.updateProfile);
+
 vi.mock('react-router-dom', async () => {
   const actual: any = await vi.importActual('react-router-dom');
   return { ...actual, useNavigate: () => vi.fn() };
@@ -24,17 +27,30 @@ beforeAll(() => {
 test('scrolls to first invalid field when finish fails validation', async () => {
   const { container } = render(<ProfileSetupPage />);
   // complete step 1
-  fireEvent.change(screen.getByLabelText(/first name/i), { target: { value: 'A' } });
-  fireEvent.change(screen.getByLabelText(/last name/i), { target: { value: 'B' } });
-  fireEvent.change(screen.getByLabelText(/phone/i), { target: { value: '(123) 456-7890' } });
+  fireEvent.change(screen.getByLabelText(/first name/i), {
+    target: { value: 'A' },
+  });
+  fireEvent.change(screen.getByLabelText(/last name/i), {
+    target: { value: 'B' },
+  });
+  fireEvent.change(screen.getByLabelText(/phone/i), {
+    target: { value: '(123) 456-7890' },
+  });
   fireEvent.click(screen.getByRole('button', { name: /next/i }));
   await screen.findByRole('button', { name: /finish/i });
 
-  const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+  const fileInput = container.querySelector(
+    'input[type="file"]',
+  ) as HTMLInputElement;
   const scrollSpy = vi.fn();
-  Object.defineProperty(fileInput, 'scrollIntoView', { value: scrollSpy, writable: true });
+  Object.defineProperty(fileInput, 'scrollIntoView', {
+    value: scrollSpy,
+    writable: true,
+  });
 
-  fireEvent.change(screen.getByLabelText(/city\/town/i), { target: { value: 'Halifax' } });
+  fireEvent.change(screen.getByLabelText(/city\/town/i), {
+    target: { value: 'Halifax' },
+  });
   const invalidFile = new File(['bad'], 'bad.txt', { type: 'text/plain' });
   fireEvent.change(fileInput, { target: { files: [invalidFile] } });
   fireEvent.click(screen.getByRole('button', { name: /finish/i }));
@@ -42,3 +58,28 @@ test('scrolls to first invalid field when finish fails validation', async () => 
   expect(scrollSpy).toHaveBeenCalled();
 });
 
+test('shows toast when profile update fails', async () => {
+  updateProfileMock.mockRejectedValueOnce(new Error('Oops'));
+
+  render(<ProfileSetupPage />);
+
+  fireEvent.change(screen.getByLabelText(/first name/i), {
+    target: { value: 'A' },
+  });
+  fireEvent.change(screen.getByLabelText(/last name/i), {
+    target: { value: 'B' },
+  });
+  fireEvent.change(screen.getByLabelText(/phone/i), {
+    target: { value: '(123) 456-7890' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: /next/i }));
+  await screen.findByRole('button', { name: /finish/i });
+
+  fireEvent.change(screen.getByLabelText(/city\/town/i), {
+    target: { value: 'Halifax' },
+  });
+
+  fireEvent.click(screen.getByRole('button', { name: /finish/i }));
+
+  expect(await screen.findByRole('status')).toHaveTextContent('Oops');
+});


### PR DESCRIPTION
## Summary
- import `Toast` into `ProfileSetupPage`
- show a toast message when `updateProfile` fails
- add a dismiss handler for the toast
- test toast behaviour when the profile update rejects

## Testing
- `npm test` within `frontend-app`
- `npm test` within `server`

------
https://chatgpt.com/codex/tasks/task_e_684acca5039483328ba377fb1fef9a66