### PR TITLE
Set onboarding flag on visit

### DIFF
--- a/frontend-app/src/screens/WelcomeScreen.tsx
+++ b/frontend-app/src/screens/WelcomeScreen.tsx
@@ -10,6 +10,12 @@ export default function WelcomeScreen() {
   const navigate = useNavigate();
   const [pulse, setPulse] = useState(false);
 
+  // Immediately mark onboarding as complete once the user lands here so
+  // subsequent visits can bypass this screen.
+  useEffect(() => {
+    localStorage.setItem('onboarding-complete', 'true');
+  }, []);
+
   useEffect(() => {
     if (
       localStorage.getItem('onboarding-complete') === 'true' ||

--- a/frontend-app/src/screens/__tests__/WelcomeScreen.test.tsx
+++ b/frontend-app/src/screens/__tests__/WelcomeScreen.test.tsx
@@ -25,13 +25,25 @@ test('shows first name in welcome message', () => {
   expect(screen.getByText(/welcome, john/i)).toBeInTheDocument();
 });
 
-test('cta stores flag and navigates', async () => {
+test('sets flag on mount and CTA navigates', async () => {
   render(<WelcomeScreen />);
-  fireEvent.click(screen.getByRole('button', { name: /post your first job/i }));
   await waitFor(() =>
     expect(localStorage.getItem('onboarding-complete')).toBe('true'),
   );
+  fireEvent.click(screen.getByRole('button', { name: /post your first job/i }));
   expect(navigateMock).toHaveBeenCalledWith('/job/new');
+});
+
+test('leaving and returning redirects to dashboard', async () => {
+  const { unmount } = render(<WelcomeScreen />);
+  await waitFor(() =>
+    expect(localStorage.getItem('onboarding-complete')).toBe('true'),
+  );
+  navigateMock.mockClear();
+  unmount();
+
+  render(<WelcomeScreen />);
+  expect(navigateMock).toHaveBeenCalledWith('/dashboard', { replace: true });
 });
 
 test('redirects to dashboard when complete', () => {


### PR DESCRIPTION
## Summary
- mark onboarding complete as soon as WelcomeScreen mounts so it is skipped on future visits
- update WelcomeScreen tests for new behavior and add scenario for leaving and returning

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684ad34ba7f0833290cb1ad92aaf7c06