### PR TITLE
Add button loading indicator

### DIFF
--- a/frontend-app/src/screens/WelcomeScreen.tsx
+++ b/frontend-app/src/screens/WelcomeScreen.tsx
@@ -3,12 +3,14 @@ import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { Handshake } from 'lucide-react';
 import { Button } from '../components/Button';
+import { Spinner } from '../components/Spinner';
 import { useAuthStore } from '../store/useAuthStore';
 
 export default function WelcomeScreen() {
   const profile = useAuthStore((s) => s.profile);
   const navigate = useNavigate();
   const [pulse, setPulse] = useState(false);
+  const [loading, setLoading] = useState(false);
 
   // Immediately mark onboarding as complete once the user lands here so
   // subsequent visits can bypass this screen.
@@ -33,6 +35,7 @@ export default function WelcomeScreen() {
   const firstName = profile?.fullName?.split(' ')[0] || 'there';
 
   const handlePostJob = () => {
+    setLoading(true);
     localStorage.setItem('onboarding-complete', 'true');
     navigate('/job/new');
   };
@@ -66,8 +69,14 @@ export default function WelcomeScreen() {
         <motion.div variants={item}>
           <Button
             onClick={handlePostJob}
-            className={pulse ? 'animate-pulse' : ''}
+            disabled={loading}
+            className={
+              pulse
+                ? 'animate-pulse flex items-center justify-center'
+                : 'flex items-center justify-center'
+            }
           >
+            {loading && <Spinner className="mr-2 text-white" />}
             Post Your First Job
           </Button>
         </motion.div>

--- a/frontend-app/src/screens/__tests__/WelcomeScreen.test.tsx
+++ b/frontend-app/src/screens/__tests__/WelcomeScreen.test.tsx
@@ -30,7 +30,10 @@ test('sets flag on mount and CTA navigates', async () => {
   await waitFor(() =>
     expect(localStorage.getItem('onboarding-complete')).toBe('true'),
   );
-  fireEvent.click(screen.getByRole('button', { name: /post your first job/i }));
+  const button = screen.getByRole('button', { name: /post your first job/i });
+  fireEvent.click(button);
+  expect(button).toBeDisabled();
+  expect(button.querySelector('svg.animate-spin')).toBeInTheDocument();
   expect(navigateMock).toHaveBeenCalledWith('/job/new');
 });
 


### PR DESCRIPTION
## Summary
- show a Spinner while posting the first job
- disable Post Job button and show spinner during navigation
- test for disabled button and spinner

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ad451c2848332a5e66d0e43cfcf49