### PR TITLE
Fix onboarding welcome flow

### DIFF
--- a/frontend-app/src/screens/WelcomeScreen.tsx
+++ b/frontend-app/src/screens/WelcomeScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { Handshake } from 'lucide-react';
 import { Button } from '../components/Button';
@@ -11,12 +11,6 @@ export default function WelcomeScreen() {
   const navigate = useNavigate();
   const [pulse, setPulse] = useState(false);
   const [loading, setLoading] = useState(false);
-
-  // Immediately mark onboarding as complete once the user lands here so
-  // subsequent visits can bypass this screen.
-  useEffect(() => {
-    localStorage.setItem('onboarding-complete', 'true');
-  }, []);
 
   useEffect(() => {
     if (
@@ -34,10 +28,19 @@ export default function WelcomeScreen() {
 
   const firstName = profile?.fullName?.split(' ')[0] || 'there';
 
+  const markComplete = () => {
+    localStorage.setItem('onboarding-complete', 'true');
+  };
+
   const handlePostJob = () => {
     setLoading(true);
-    localStorage.setItem('onboarding-complete', 'true');
+    markComplete();
     navigate('/job/new');
+  };
+
+  const handleExplore = () => {
+    markComplete();
+    navigate('/dashboard', { replace: true });
   };
 
   const container = {
@@ -55,10 +58,13 @@ export default function WelcomeScreen() {
         variants={container}
         initial="hidden"
         animate="show"
-        className="w-full max-w-md space-y-6 text-center"
+        className="w-full max-w-xl space-y-6 text-center"
       >
         <motion.div variants={item}>
-          <Handshake className="mx-auto size-20 text-primary" aria-hidden="true" />
+          <Handshake
+            className="mx-auto size-20 text-primary"
+            aria-hidden="true"
+          />
         </motion.div>
         <p className="sr-only" aria-live="polite">
           {`Welcome, ${firstName}! You're ready to post your first job.`}
@@ -69,7 +75,7 @@ export default function WelcomeScreen() {
         <motion.p variants={item} className="text-lg">
           We&apos;re glad you&apos;re here!
         </motion.p>
-        <motion.div variants={item}>
+        <motion.div variants={item} className="space-y-4">
           <Button
             onClick={handlePostJob}
             disabled={loading}
@@ -82,6 +88,15 @@ export default function WelcomeScreen() {
             {loading && <Spinner className="mr-2 text-white" />}
             Post Your First Job
           </Button>
+          <div>
+            <button
+              onClick={handleExplore}
+              className="text-primary underline"
+              type="button"
+            >
+              Explore Dashboard
+            </button>
+          </div>
         </motion.div>
       </motion.div>
     </div>

--- a/frontend-app/src/screens/__tests__/WelcomeScreen.test.tsx
+++ b/frontend-app/src/screens/__tests__/WelcomeScreen.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import WelcomeScreen from '../WelcomeScreen';
@@ -36,23 +36,33 @@ test('handshake icon is hidden from assistive tech and sr message exists', () =>
   ).toHaveClass('sr-only');
 });
 
-test('sets flag on mount and CTA navigates', async () => {
+test('does not set flag on mount', () => {
   render(<WelcomeScreen />);
-  await waitFor(() =>
-    expect(localStorage.getItem('onboarding-complete')).toBe('true'),
-  );
+  expect(localStorage.getItem('onboarding-complete')).toBe(null);
+});
+
+test('CTA sets flag and navigates', () => {
+  render(<WelcomeScreen />);
   const button = screen.getByRole('button', { name: /post your first job/i });
   fireEvent.click(button);
   expect(button).toBeDisabled();
   expect(button.querySelector('svg.animate-spin')).toBeInTheDocument();
+  expect(localStorage.getItem('onboarding-complete')).toBe('true');
   expect(navigateMock).toHaveBeenCalledWith('/job/new');
 });
 
-test('leaving and returning redirects to dashboard', async () => {
+test('explore link sets flag and navigates', () => {
+  render(<WelcomeScreen />);
+  const link = screen.getByRole('button', { name: /explore dashboard/i });
+  fireEvent.click(link);
+  expect(localStorage.getItem('onboarding-complete')).toBe('true');
+  expect(navigateMock).toHaveBeenCalledWith('/dashboard', { replace: true });
+});
+
+test('leaving and returning redirects to dashboard', () => {
   const { unmount } = render(<WelcomeScreen />);
-  await waitFor(() =>
-    expect(localStorage.getItem('onboarding-complete')).toBe('true'),
-  );
+  const link = screen.getByRole('button', { name: /explore dashboard/i });
+  fireEvent.click(link);
   navigateMock.mockClear();
   unmount();
 


### PR DESCRIPTION
## Summary
- adjust WelcomeScreen to not mark onboarding complete on mount
- update WelcomeScreen tests
- add explore-dashboard link and related tests

## Testing
- `npm test --silent -- --run` in `frontend-app`
- `npm test --silent` in `server`


------
https://chatgpt.com/codex/tasks/task_e_684ad782d1a88332a9ab5cb7dabbf21e