### PR TITLE
Implement contractor dashboard

### DIFF
--- a/frontend-app/src/features/dashboard/ContractorDashboard.tsx
+++ b/frontend-app/src/features/dashboard/ContractorDashboard.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { Button } from '../../components/Button';
+import { useAuthStore } from '../../store/useAuthStore';
+import dashboardService, { DashboardData } from '../../services/dashboardService';
+
+export default function ContractorDashboard() {
+  const profile = useAuthStore((s) => s.profile);
+  const [data, setData] = useState<DashboardData | null>(null);
+  const [error, setError] = useState(false);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    dashboardService
+      .getDashboard()
+      .then(setData)
+      .catch(() => setError(true));
+  }, []);
+
+  if (error) {
+    return (
+      <div className="p-4 text-center text-red-600">
+        Unable to load dashboard. Please try again.
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="p-4 text-center">Loading...</div>
+    );
+  }
+
+  const firstName = profile?.fullName?.split(' ')[0] || 'there';
+  const { stats, leads } = data;
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-4 p-4 md:grid md:grid-cols-2 md:gap-4 md:space-y-0">
+      {!profile?.isActive && (
+        <div className="rounded border border-primary bg-white p-3 text-sm shadow-sm">
+          Your profile is still under review
+        </div>
+      )}
+      <h1 className="text-2xl font-bold">Welcome back, {firstName}!</h1>
+
+      <section className="rounded border bg-white p-4 shadow-sm md:col-span-2">
+        <h2 className="mb-4 text-lg font-semibold">Quote &amp; Job Overview</h2>
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4 text-center">
+          <Link
+            to="/jobs?status=awaiting"
+            className="focus:outline-none focus:ring rounded"
+            aria-label="Leads Awaiting Quote"
+          >
+            <div className="text-2xl font-bold" data-testid="awaiting">
+              {stats.leadsAwaitingQuote}
+            </div>
+            <div className="text-sm">Leads Awaiting Quote</div>
+          </Link>
+          <Link
+            to="/quotes?status=sent"
+            className="focus:outline-none focus:ring rounded"
+            aria-label="Quotes Sent"
+          >
+            <div className="text-2xl font-bold">{stats.quotesSent}</div>
+            <div className="text-sm">Quotes Sent</div>
+          </Link>
+          <Link
+            to="/jobs?status=inprogress"
+            className="focus:outline-none focus:ring rounded"
+            aria-label="Jobs in Progress"
+          >
+            <div className="text-2xl font-bold">{stats.jobsInProgress}</div>
+            <div className="text-sm">Jobs in Progress</div>
+          </Link>
+          <Link
+            to="/jobs?status=completed"
+            className="focus:outline-none focus:ring rounded"
+            aria-label="Completed Jobs"
+          >
+            <div className="text-2xl font-bold">{stats.completedJobs}</div>
+            <div className="text-sm">Completed Jobs</div>
+          </Link>
+        </div>
+      </section>
+
+      <section className="rounded border bg-white p-4 shadow-sm md:col-span-1">
+        <h2 className="mb-2 text-lg font-semibold">New Job Leads In Your Area</h2>
+        {leads.length > 0 ? (
+          <ul className="space-y-3">
+            {leads.slice(0, 5).map((lead) => (
+              <li key={lead.id} className="flex items-center justify-between">
+                <Link
+                  to={`/leads/${lead.id}`}
+                  className="flex-1 focus:outline-none focus:ring rounded"
+                >
+                  <div className="font-medium">{lead.title}</div>
+                  <div className="text-sm text-gray-500">
+                    {lead.location}
+                    {lead.budget ? ` • ${lead.budget}` : ''}
+                  </div>
+                  {lead.description && (
+                    <p className="text-sm text-gray-500 line-clamp-2">
+                      {lead.description}
+                    </p>
+                  )}
+                </Link>
+                <Button
+                  variant="outline"
+                  className="ml-2 text-sm"
+                  onClick={() => navigate(`/quote/new?leadId=${lead.id}`)}
+                >
+                  Quote Now
+                </Button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-gray-500" data-testid="no-leads">
+            No new leads right now – check back soon.
+          </p>
+        )}
+      </section>
+
+      <section className="rounded border bg-white p-4 shadow-sm">
+        <h2 className="mb-2 text-lg font-semibold">Quick Actions</h2>
+        <ul className="space-y-2">
+          <li>
+            <Link to="/profile-setup" className="text-primary hover:underline">
+              Edit Profile
+            </Link>
+          </li>
+          <li>
+            <Link to="/availability" className="text-primary hover:underline">
+              Set Availability
+            </Link>
+          </li>
+          <li>
+            <Link to="/quotes" className="text-primary hover:underline">
+              View Quotes
+            </Link>
+          </li>
+          <li>
+            <Link to="/quotes/new" className="text-primary hover:underline">
+              + Add a Manual Quote
+            </Link>
+          </li>
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/frontend-app/src/features/dashboard/__tests__/ContractorDashboard.test.tsx
+++ b/frontend-app/src/features/dashboard/__tests__/ContractorDashboard.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import ContractorDashboard from '../ContractorDashboard';
+
+let profile: any;
+
+vi.mock('../../../store/useAuthStore', () => ({
+  useAuthStore: (selector: any) => selector({ profile }),
+}));
+
+vi.mock('../../../services/dashboardService', () => ({
+  default: { getDashboard: vi.fn() },
+}));
+
+import dashboardService from '../../../services/dashboardService';
+const getDashboardMock = vi.mocked(dashboardService.getDashboard);
+
+test('renders welcome header and stats', async () => {
+  profile = { fullName: 'Jane Doe', isActive: true };
+  getDashboardMock.mockResolvedValue({
+    stats: { leadsAwaitingQuote: 1, quotesSent: 2, jobsInProgress: 0, completedJobs: 3 },
+    leads: [],
+  });
+
+  render(
+    <MemoryRouter>
+      <ContractorDashboard />
+    </MemoryRouter>,
+  );
+
+  await waitFor(() => {
+    expect(screen.getByText(/welcome back, jane/i)).toBeInTheDocument();
+  });
+  const awaiting = screen.getByTestId('awaiting');
+  expect(awaiting).toHaveTextContent('1');
+  expect(awaiting.closest('a')).toHaveAttribute('href', '/jobs?status=awaiting');
+});
+
+test('shows no leads message when list is empty', async () => {
+  profile = { fullName: 'Jane Doe', isActive: true };
+  getDashboardMock.mockResolvedValue({
+    stats: { leadsAwaitingQuote: 0, quotesSent: 0, jobsInProgress: 0, completedJobs: 0 },
+    leads: [],
+  });
+
+  render(
+    <MemoryRouter>
+      <ContractorDashboard />
+    </MemoryRouter>,
+  );
+
+  await waitFor(() => {
+    expect(screen.getByTestId('no-leads')).toBeInTheDocument();
+  });
+});
+
+test('quick actions link to profile page', async () => {
+  profile = { fullName: 'Jane Doe', isActive: true };
+  getDashboardMock.mockResolvedValue({
+    stats: { leadsAwaitingQuote: 0, quotesSent: 0, jobsInProgress: 0, completedJobs: 0 },
+    leads: [],
+  });
+
+  render(
+    <MemoryRouter>
+      <ContractorDashboard />
+    </MemoryRouter>,
+  );
+
+  await waitFor(() => {
+    expect(screen.getByText(/quick actions/i)).toBeInTheDocument();
+  });
+
+  expect(
+    screen.getByRole('link', { name: /edit profile/i }),
+  ).toHaveAttribute('href', '/profile-setup');
+});

--- a/frontend-app/src/main.tsx
+++ b/frontend-app/src/main.tsx
@@ -4,7 +4,7 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import LoginPage from './features/auth/LoginPage';
 import SignupPage from './features/auth/SignupPage';
 import EmailVerificationPage from './features/auth/EmailVerificationPage';
-import Dashboard from './features/dashboard/Dashboard';
+import ContractorDashboard from './features/dashboard/ContractorDashboard';
 import ProfileSetupPage from './features/onboarding/ProfileSetupPage';
 import BusinessTradePage from './features/onboarding/BusinessTradePage';
 import LegalCredentialsPage from './features/onboarding/LegalCredentialsPage';
@@ -31,7 +31,7 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
             <Route path="/home" element={<HomePage />} />
             <Route path="/login" element={<LoginPage />} />
             <Route path="/signup" element={<SignupPage />} />
-            <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/dashboard" element={<ContractorDashboard />} />
             <Route path="/verify-email" element={<EmailVerificationPage />} />
             <Route path="/profile-setup" element={<ProfileSetupPage />} />
             <Route path="/business-profile" element={<BusinessTradePage />} />

--- a/frontend-app/src/services/dashboardService.ts
+++ b/frontend-app/src/services/dashboardService.ts
@@ -1,0 +1,49 @@
+export interface DashboardStats {
+  leadsAwaitingQuote: number;
+  quotesSent: number;
+  jobsInProgress: number;
+  completedJobs: number;
+}
+
+export interface LeadSummary {
+  id: string;
+  title: string;
+  location?: string;
+  budget?: string;
+  description?: string;
+}
+
+export interface DashboardData {
+  stats: DashboardStats;
+  leads: LeadSummary[];
+}
+
+const getDashboard = async (): Promise<DashboardData> => {
+  // This would normally fetch data from the API
+  return Promise.resolve({
+    stats: {
+      leadsAwaitingQuote: 2,
+      quotesSent: 5,
+      jobsInProgress: 1,
+      completedJobs: 12,
+    },
+    leads: [
+      {
+        id: '1',
+        title: 'Bathroom Renovation',
+        location: 'Halifax',
+        budget: '$5k',
+        description: 'Update fixtures and tiling',
+      },
+      {
+        id: '2',
+        title: 'Deck Repair',
+        location: 'Dartmouth',
+        budget: '$2k',
+        description: 'Replace rotten boards',
+      },
+    ],
+  });
+};
+
+export default { getDashboard };


### PR DESCRIPTION
## Summary
- add stub `dashboardService`
- add `ContractorDashboard` component displaying stats, leads, quick actions
- route `/dashboard` to new contractor dashboard
- test contractor dashboard behavior
- improve contractor dashboard links and accessibility

## Testing
- `npm --prefix frontend-app install`
- `npm --prefix frontend-app test`


------
https://chatgpt.com/codex/tasks/task_e_684b3b17228083329b218e2fb44a08f6